### PR TITLE
Ingestion airbyte api

### DIFF
--- a/dags/awl-bg-tracker-docker.py
+++ b/dags/awl-bg-tracker-docker.py
@@ -5,14 +5,18 @@ import os
 
 import requests
 from airflow import DAG
+from airflow.hooks.base import BaseHook
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
 from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.utils.dates import days_ago
 
 from lib.Airbyte import AirbyteAPI
+from lib.utils import (update_json)
 
 project_home = Variable.get("PROJECT_HOME")
+minio_conn = BaseHook.get_connection("minio")
+mongodb_conn = BaseHook.get_connection("mongodb")
 
 default_args = {
     'owner': 'gabrielmelocomp',
@@ -35,19 +39,19 @@ dag = DAG(
 t1 = DockerOperator(
     task_id='crawler_container',
     image='gabrielmmelo/awl-crawler:latest',
-    # volumes=[''.join([project_home, 'certs/CAs:/usr/src/app/mkcert'])],
     network_mode="host",
     environment={
         # "MONGODB_HOST": "host.docker.internal",
         # "MONGODB_PORT": 27017,
-        # "MONGODB_DB": "middleware",
         # "MONGODB_DOCUMENTS_TTL": 259200,  # in seconds
         # "MONGODB_TIMEZONE": "America/Sao_Paulo",
+        "MONGODB_DB": "staging",
         "MONGODB_COLLECTION": str(dag.dag_id)
     },
     do_xcom_push=False,
     dag=dag
 )
+
 
 def airbyte_create_connection():
     ab = AirbyteAPI(
@@ -56,27 +60,85 @@ def airbyte_create_connection():
         ssl=False
     )
 
-    logging.info("Getting workspace id by email")
     workspace_id = ab.get_workspace_id_by_email("gabrielmelocomp@gmail.com")
-    logging.info("Workspace ID: " + workspace_id)
+    logging.debug("Workspace ID: " + workspace_id)
 
-    if not ab.source_exists(workspace_id=workspace_id, source_name=str(dag.dag_id)):
+    logging.info("Checking if source already exists...")
+    source_id = ab.get_source_by_name(workspace_id=workspace_id, source_name=str(dag.dag_id))
+    if not source_id:
+        logging.info("Creating new source...")
         source_definition_id = ab.get_source_definition_id_by_repository(repository="airbyte/source-mongodb")
-        logging.info("Source Definition ID: " + source_definition_id)
+        logging.debug("Source Definition ID: " + source_definition_id)
 
         with open('dags/connections/sourceMongoDb.json', 'r') as f:
             connection_configuration = json.loads(f.read())["connectionConfiguration"]
-            # TODO: update connection_configuration password field with env var
-            logging.info(connection_configuration)
+            logging.debug("Connection Configuration:")
+            logging.debug(connection_configuration)
 
-        ab.create_source(
+        connection_configuration = update_json(
+            json=connection_configuration,
+            user=mongodb_conn.login,
+            password=mongodb_conn.password
+        )
+
+        source_id = ab.create_source(
             name=dag.dag_id,
             workspace_id=workspace_id,
             source_definition_id=source_definition_id,
             connection_configuration=connection_configuration
         )
     else:
-        pass
+        logging.info("Source already exists.")
+
+    logging.info("Checking if destination already exists...")
+    destination_id = ab.get_destination_by_name(workspace_id=workspace_id, destination_name=str(dag.dag_id))
+    if not destination_id:
+        logging.info("Creating new destination...")
+        destination_definition_id = ab.get_destination_definition_id_by_repository(repository="airbyte/destination-s3")
+        logging.debug("Destination Definition ID: " + destination_definition_id)
+
+        with open('dags/connections/destinationMinIO.json', 'r') as f:
+            connection_configuration = json.loads(f.read())["connectionConfiguration"]
+            logging.debug("Connection Configuration:")
+            logging.debug(connection_configuration)
+
+        connection_configuration = update_json(
+            json=connection_configuration,
+            access_key_id=minio_conn.login,
+            secret_access_key=minio_conn.password
+        )
+
+        destination_id = ab.create_destination(
+            name=dag.dag_id,
+            workspace_id=workspace_id,
+            destination_definition_id=destination_definition_id,
+            connection_configuration=connection_configuration
+        )
+    else:
+        logging.info("Destination already exists.")
+
+    logging.info("Checking if connection already exists...")
+    connection_id = ab.get_connection_by_source_and_destination(workspace_id=workspace_id, source_id=source_id, destination_id=destination_id)
+    if not connection_id:
+        logging.info("Creating new connection...")
+        with open('dags/connections/connectionTemplate.json', 'r') as f:
+            configuration_template = json.loads(f.read())
+            logging.debug("Connection template:")
+            logging.debug(configuration_template)
+
+        # TODO: create utils function to fill the template, instead of doing that in create_connection function
+        # configuration_template = fill_json(configuration_template)
+
+        source_stream = ab.get_source_stream(source_id=source_id)
+
+        ab.create_connection(
+            source_stream=source_stream,
+            source_id=source_id,
+            destination_id=destination_id,
+            configuration_template=configuration_template
+        )
+    else:
+        logging.info("Connection already exists.")
 
 
 t2 = PythonOperator(

--- a/dags/awl-bg-tracker-docker.py
+++ b/dags/awl-bg-tracker-docker.py
@@ -45,7 +45,7 @@ t1 = DockerOperator(
         # "MONGODB_PORT": 27017,
         # "MONGODB_DOCUMENTS_TTL": 259200,  # in seconds
         # "MONGODB_TIMEZONE": "America/Sao_Paulo",
-        "MONGODB_DB": "staging",
+        "MONGODB_DB": str(dag.dag_id),
         "MONGODB_COLLECTION": str(dag.dag_id)
     },
     do_xcom_push=False,
@@ -77,6 +77,7 @@ def airbyte_create_connection():
 
         connection_configuration = update_json(
             json=connection_configuration,
+            database=dag.dag_id,
             user=mongodb_conn.login,
             password=mongodb_conn.password
         )

--- a/dags/connections/connectionTemplate.json
+++ b/dags/connections/connectionTemplate.json
@@ -1,0 +1,41 @@
+{
+  "name": "default",
+  "namespaceDefinition": "source",
+  "namespaceFormat": "${SOURCE_NAMESPACE}",
+  "prefix": "",
+  "sourceId": "SOURCE_ID",
+  "destinationId": "DESTINATION_ID",
+  "operationIds": [],
+  "syncCatalog": {
+    "streams": [
+      {
+        "stream": {
+          "name": "STREAM_NAME",
+          "jsonSchema": {},
+          "supportedSyncModes": [
+            "full_refresh",
+            "incremental"
+          ],
+          "sourceDefinedCursor": false,
+          "defaultCursorField": [],
+          "sourceDefinedPrimaryKey": [],
+          "namespace": null
+        },
+        "config": {
+          "syncMode": "full_refresh",
+          "destinationSyncMode": "append",
+          "primaryKey": [],
+          "selected": true
+        }
+      }
+    ]
+  },
+  "schedule": null,
+  "status": "active",
+  "resourceRequirements": {
+    "cpu_request": null,
+    "cpu_limit": null,
+    "memory_request": null,
+    "memory_limit": null
+  }
+}

--- a/dags/connections/destinationMinIO.json
+++ b/dags/connections/destinationMinIO.json
@@ -1,0 +1,19 @@
+{
+  "connectionConfiguration": {
+    "format": {
+      "format_type": "Parquet",
+      "page_size_kb": 1024,
+      "block_size_mb": 128,
+      "compression_codec": "UNCOMPRESSED",
+      "dictionary_encoding": true,
+      "max_padding_size_mb": 8,
+      "dictionary_page_size_kb": 1024
+    },
+    "s3_endpoint": "http://rpi.home.net:9000",
+    "access_key_id": "***",
+    "s3_bucket_name": "lake",
+    "s3_bucket_path": "dev/01_raw",
+    "s3_bucket_region": "us-east-1",
+    "secret_access_key": "***"
+  }
+}

--- a/dags/connections/sourceMongoDb.json
+++ b/dags/connections/sourceMongoDb.json
@@ -3,9 +3,9 @@
     "ssl": false,
     "host": "host.docker.internal",
     "port": 27017,
-    "user": "root",
-    "database": "ods",
-    "password": "root123",
+    "user": "***",
+    "database": "staging",
+    "password": "***",
     "auth_source": "admin",
     "replica_set": ""
   }

--- a/dags/lib/Airbyte.py
+++ b/dags/lib/Airbyte.py
@@ -174,4 +174,30 @@ class AirbyteAPI():
         response = connection_creation.json()
         logging.info(response)
 
-        return response
+        return response.get("connectionId")
+
+    def sync_connection(self, connection_id):
+        """Trigger a manual sync for a connection."""
+        sync_connections_endpoint = "/api/v1/connections/sync"
+        sync_connections_url = self.url + sync_connections_endpoint
+        data = {
+            "connectionId": connection_id
+        }
+        response = requests.post(sync_connections_url, data=json.dumps(data),
+                                 headers={'Content-Type': "application/json"})
+        job = response.json()
+
+        return job.get("job").get("id")
+
+    def get_job_status(self, job_id):
+        """Returns the current status from a given job."""
+        get_job_endpoint = "/api/v1/jobs/get"
+        get_job_url = self.url + get_job_endpoint
+        data = {
+            "id": job_id
+        }
+        response = requests.post(get_job_url, data=json.dumps(data),
+                                 headers={'Content-Type': "application/json"})
+        job = response.json()
+
+        return job.get("job").get("status")

--- a/dags/lib/Airbyte.py
+++ b/dags/lib/Airbyte.py
@@ -4,48 +4,50 @@ import requests
 
 
 class AirbyteAPI():
-    # TODO: use default e-mail as the airflow admin user email
     def __init__(self, host="localhost", port=8888, ssl=False):
         self.host = host
         self.port = port
         self.ssl = ssl
         self.url = "".join(["https://" if self.ssl else "http://", self.host, ":", str(self.port)])
 
-    def source_exists(self, workspace_id: str, source_name: str) -> bool:
+    # TODO: change it for a more reliable approach
+    def get_workspace_id_by_email(self, email):
+        """Get workspace id by a given email (NOTE: its a temporary approach)"""
+        list_workspaces_endpoint = "/api/v1/workspaces/list"
+        list_workspaces_url = self.url + list_workspaces_endpoint
+        response = requests.post(list_workspaces_url, headers={'Content-Type': "application/json"})
+        workspaces = response.json()
+        logging.debug(workspaces)
+        workspace_id = list(filter(lambda x: x["email"] == email, workspaces.get("workspaces")))[0].get("workspaceId")
+        return workspace_id
+
+    def get_source_by_name(self, workspace_id: str, source_name: str) -> bool:
         """Check if a given source_name (By default, the dag's id) exists in airbyte. Returns the id, if it exists"""
         list_sources_endpoint = "/api/v1/sources/list"
         list_sources_url = self.url + list_sources_endpoint
         data = {
             "workspaceId": workspace_id
         }
-        sources = requests.post(list_sources_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
-        response = sources.json()
-        logging.debug(response)
-        source = list(filter(lambda x: x["name"] == source_name, response.get("sources")))
+        response = requests.post(list_sources_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
+        sources = response.json()
+        logging.debug(sources)
+        try:
+            source = list(filter(lambda x: x["name"] == source_name, sources.get("sources")))[0]
+        except IndexError:
+            return None
 
-        return len(source) > 0
-
-    # TODO: change it for a more reliable approach
-    def get_workspace_id_by_email(self, email):
-        """Get workspace id by a given email (NOTE: its a temporary approach)"""
-        list_workspaces_endpoint = "/api/v1/workspaces/list"
-        list_workspaces_url = self.url + list_workspaces_endpoint
-        workspaces = requests.post(list_workspaces_url, headers={'Content-Type': "application/json"})
-        response = workspaces.json()
-        logging.debug(response)
-        workspace_id = list(filter(lambda x: x["email"] == email, response.get("workspaces")))[0].get("workspaceId")
-        return workspace_id
+        return source.get("sourceId", None)
 
     def get_source_definition_id_by_repository(self, repository):
         """Get source definition id by DockerHub repository name."""
         list_source_definitions_endpoint = "/api/v1/source_definitions/list"
         list_source_definitions_url = self.url + list_source_definitions_endpoint
-        source_definitions = requests.post(list_source_definitions_url, headers={'Content-Type': "application/json"})
-        response = source_definitions.json()
-        logging.debug(response)
+        response = requests.post(list_source_definitions_url, headers={'Content-Type': "application/json"})
+        source_definitions = response.json()
+        logging.debug(source_definitions)
         source_definition_id = \
             list(
-                filter(lambda x: x["dockerRepository"] == repository, response.get("sourceDefinitions")))[
+                filter(lambda x: x["dockerRepository"] == repository, source_definitions.get("sourceDefinitions")))[
                 0].get(
                 "sourceDefinitionId")
         return source_definition_id
@@ -61,8 +63,115 @@ class AirbyteAPI():
 
         create_sources_endpoint = "/api/v1/sources/create"
         create_sources_url = self.url + create_sources_endpoint
-        source_creation = requests.post(create_sources_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
-        response = source_creation.json()
-        logging.info(response)
-        return response
+        response = requests.post(create_sources_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
+        source = response.json()
 
+        return source.get("sourceId")
+
+    def get_destination_by_name(self, workspace_id: str, destination_name: str) -> str:
+        """Check if a given destination_name (By default, the dag's id) exists in airbyte. Returns the id, if it exists"""
+        list_destinations_endpoint = "/api/v1/destinations/list"
+        list_destinations_url = self.url + list_destinations_endpoint
+        data = {
+            "workspaceId": workspace_id
+        }
+        response = requests.post(list_destinations_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
+        destinations = response.json()
+        logging.debug(destinations)
+        try:
+            destination = list(filter(lambda x: x["name"] == destination_name, destinations.get("destinations")))[0]
+        except IndexError:
+            return None
+
+        return destination.get("destinationId", None)
+
+    def get_destination_definition_id_by_repository(self, repository):
+        """Get destination definition id by DockerHub repository name."""
+        list_destination_definitions_endpoint = "/api/v1/destination_definitions/list"
+        list_destination_definitions_url = self.url + list_destination_definitions_endpoint
+        response = requests.post(list_destination_definitions_url, headers={'Content-Type': "application/json"})
+        destination_definitions = response.json()
+        logging.debug(destination_definitions)
+        destination_definition_id = \
+            list(
+                filter(lambda x: x["dockerRepository"] == repository, destination_definitions.get("destinationDefinitions")))[
+                0].get(
+                "destinationDefinitionId")
+        return destination_definition_id
+
+    def create_destination(self, name, workspace_id, destination_definition_id, connection_configuration):
+        """Create a destination in Airbyte."""
+        data = {
+            "destinationDefinitionId": destination_definition_id,
+            "workspaceId": workspace_id,
+            "connectionConfiguration": connection_configuration,
+            "name": name
+        }
+
+        create_destinations_endpoint = "/api/v1/destinations/create"
+        create_destinations_url = self.url + create_destinations_endpoint
+        response = requests.post(create_destinations_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
+        destination = response.json()
+
+        return destination.get("destinationId")
+
+    def get_source_stream(self, source_id):
+        """Returns source stream, including discovered schema and supported sync methods."""
+        data = {
+            "sourceId": source_id
+        }
+
+        get_stream_endpoint = "/api/v1/sources/discover_schema"
+        get_stream_url = self.url + get_stream_endpoint
+        response = requests.post(get_stream_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
+        catalog = response.json()
+        logging.info("Catalog:")
+        logging.info(catalog)
+
+        try:
+            stream = catalog["catalog"]["streams"][0]["stream"]
+        except IndexError:
+            return None
+
+        return stream
+
+    def get_connection_by_source_and_destination(self, workspace_id: str, source_id: str, destination_id: str) -> str:
+        """Check if a given source_name (By default, the dag's id) exists in airbyte. Returns the id, if it exists"""
+        list_connections_endpoint = "/api/v1/connections/list"
+        list_connections_url = self.url + list_connections_endpoint
+        data = {
+            "workspaceId": workspace_id
+        }
+        response = requests.post(list_connections_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
+        connections = response.json()
+        logging.info("Connections:")
+        logging.info(connections)
+        try:
+            connection = list(filter(lambda x: x["sourceId"] == source_id and x["destinationId"] == destination_id, connections.get("connections")))[0]
+        except IndexError:
+            return None
+
+        return connection.get("connectionId", None)
+
+    def create_connection(self, source_id, source_stream, destination_id, configuration_template, schedule=None):
+        """Create a connection in Airbyte."""
+
+        logging.info("Source ID: " + source_id)
+        logging.info("Destination ID: " + destination_id)
+
+        configuration_template["sourceId"] = source_id
+        configuration_template["destinationId"] = destination_id
+        configuration_template["syncCatalog"]["streams"][0]["stream"] = source_stream
+        configuration_template["schedule"] = schedule
+
+        data = configuration_template
+        logging.info("Configuration template: ")
+        logging.info(data)
+
+        create_connections_endpoint = "/api/v1/connections/create"
+        create_connections_url = self.url + create_connections_endpoint
+        connection_creation = requests.post(create_connections_url, data=json.dumps(data), headers={'Content-Type': "application/json"})
+        response = connection_creation.json()
+        logging.info(response)
+
+        return response

--- a/dags/lib/utils.py
+++ b/dags/lib/utils.py
@@ -1,0 +1,5 @@
+def update_json(json, **kwargs):
+    for key, value in kwargs.items():
+        json[key] = value
+
+    return json

--- a/images/airflow-worker/Dockerfile
+++ b/images/airflow-worker/Dockerfile
@@ -13,4 +13,5 @@ RUN groupadd -g $DOCKER_GROUP_ID docker \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*.bin 
 RUN usermod -aG docker airflow
 USER airflow
-RUN pip install --user apache-airflow-providers-apache-spark==1.0.3
+#TODO: use requirements.txt
+RUN pip install --user apache-airflow-providers-apache-spark==1.0.3 pymongo


### PR DESCRIPTION
A DAG example for data ingestion using `Airbyte` engine, `MongoDB` as data staging layer and agnostic `Docker` images as data crawlers.

The Airbyte's API was used to programmatically set up sources, destinations and connections and also trigger and monitor sync jobs.

